### PR TITLE
Drop support for Python 2.6 and 3.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-    - 2.6
     - 2.7
     - 3.3
     - 3.4
@@ -12,6 +11,6 @@ python:
 install:
     - pip install .
 script:
-    - python setup.py test -q
+    - python setup.py -q test -q
 notifications:
     email: false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,10 @@
 Change log
 ==========
 
-4.1.1 (unreleased)
+4.2.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Drop support for Python 2.6 and 3.2.
 
 
 4.1.0 (2015-04-16)

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ except ImportError:
 
 setup(
     name="zdaemon",
-    version='4.1.1.dev0',
+    version='4.2.0.dev0',
     url="https://github.com/zopefoundation/zdaemon",
     license="ZPL 2.1",
     description=
@@ -79,10 +79,8 @@ setup(
        'License :: OSI Approved :: Zope Public License',
        'Programming Language :: Python',
        'Programming Language :: Python :: 2',
-       'Programming Language :: Python :: 2.6',
        'Programming Language :: Python :: 2.7',
        'Programming Language :: Python :: 3',
-       'Programming Language :: Python :: 3.2',
        'Programming Language :: Python :: 3.3',
        'Programming Language :: Python :: 3.4',
        'Programming Language :: Python :: Implementation :: CPython',

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 #   PyPy3 support pending a release of a fix for
 #   https://bitbucket.org/pypy/pypy/issue/1946)
-#envlist = py26,py27,py32,py33,py34,pypy,pypy3
-envlist = py26,py27,py32,py33,py34,pypy
+#envlist = py27,py33,py34,pypy,pypy3
+envlist = py27,py33,py34,pypy
 
 [testenv]
 commands =
-    python setup.py test -q
+    python setup.py -q test -q
 # without explicit deps, setup.py test will download a bunch of eggs into $PWD
 deps =
     zc.customdoctests
@@ -14,7 +14,6 @@ deps =
     zope.testrunner
     manuel
     mock
-
 
 [testenv:coverage]
 usedevelop = true


### PR DESCRIPTION
- 2.6 is long out-of-maintenance, and a security quagmire.

- 3.2 cannot be tested on Travis.