### PR TITLE
Bugfix: notice programs that die too fast on Python 3.5

### DIFF
--- a/src/zdaemon/zdrun.py
+++ b/src/zdaemon/zdrun.py
@@ -380,6 +380,8 @@ class Daemonizer:
     proc = None  # Subprocess instance
 
     def runforever(self):
+        sig_r, sig_w = os.pipe()
+        signal.set_wakeup_fd(sig_w)
         self.logger.info("daemon manager started")
         while self.should_be_up or self.proc.pid:
             if self.should_be_up and not self.proc.pid and not self.delay:
@@ -389,7 +391,7 @@ class Daemonizer:
                     self.delay = time.time() + self.backofflimit
             if self.waitstatus:
                 self.reportstatus()
-            r, w, x = [self.mastersocket], [], []
+            r, w, x = [self.mastersocket, sig_r], [], []
             if self.commandsocket:
                 r.append(self.commandsocket)
             timeout = self.options.backofflimit
@@ -422,6 +424,8 @@ class Daemonizer:
                     self.logger.exception("socket.error in doaccept(): %s"
                                           % str(msg))
                     self.commandsocket = None
+            if sig_r in r:
+                os.read(sig_r, 1)  # don't let the buffer fill up
         self.logger.info("Exiting")
         sys.exit(0)
 


### PR DESCRIPTION
Background: Python 3.5 changes select.select() to handle EINTR internally ([PEP 475](https://www.python.org/dev/peps/pep-0475/)).  Our main loop used to rely on select() returning early when a SIGCHLD signal arrives, so this change broke our timing measurement logic and made a unit test fail on Python 3.5.

I implemented one of the two suggested workarounds in the PEP: signal.set_wakeup_fd() (which is available since Python 2.6) will now tell our select() to wake up whenever a signal arrives.