### PR TITLE
Fix generating documentation.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,14 +4,17 @@ name: tests
 
 on:
   push:
-    branches: [ master ]
   pull_request:
   schedule:
     - cron: '0 12 * * 0'  # run once a week on Sunday
+  # Allow to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   build:
     strategy:
+      # We want to see all failures:
+      fail-fast: false
       matrix:
         config:
         # [Python version, tox env]

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/buildout-recipe
 [meta]
 template = "buildout-recipe"
-commit-id = "9536fe3d377f6b7ac9decad648118168d978eea3"
+commit-id = "d4e8550e4a37df10866d376fceac4e91689df8c5"
 
 [python]
 with-appveyor = false
@@ -25,9 +25,11 @@ coverage-setenv = [
     "COVERAGE_PROCESS_START={toxinidir}/.coveragerc",
     "COVERAGE_HOME={toxinidir}/",
     ]
+use-flake8 = true
 
 [manifest]
 additional-rules = [
     "recursive-include src *.conf",
+    "recursive-include src *.rst",
     "recursive-include src *.xml",
     ]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,10 +6,7 @@ include buildout.cfg
 include tox.ini
 include .coveragerc
 
-recursive-include src *.pt
 recursive-include src *.py
-recursive-include src *.rst
-recursive-include src *.txt
-recursive-include src *.zcml
 recursive-include src *.conf
+recursive-include src *.rst
 recursive-include src *.xml


### PR DESCRIPTION
Use `Sphinx < 4` to prevent problems with `repoze.sphinx.autointerface`.