### PR TITLE
Fix start test program race condition

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Change log
 
 - Fix ``SIGCHLD``/``wait`` raise condition associated with the
   ``start-test-program`` option.
+  For details see `#33 <https://github.com/zopefoundation/zdaemon/pull/33>`_.
 
 
 5.0 (2023-05-24)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Change log
 5.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Fix ``SIGCHLD``/``wait`` raise condition associated with the
+  ``start-test-program`` option.
 
 
 5.0 (2023-05-24)

--- a/src/zdaemon/zdrun.py
+++ b/src/zdaemon/zdrun.py
@@ -161,7 +161,7 @@ class Subprocess:
                         # uncomment the following line to force
                         # (for testing purposes) a race between
                         # the ``wait`` below and the ``SIGCHLD`` handler
-                        #import time; time.sleep(0.01)
+                        # import time; time.sleep(0.01)
                         sts = p.wait()
                         # ``sts`` is usually the return status.
                         # However, the true return status may have been

--- a/src/zdaemon/zdrun.py
+++ b/src/zdaemon/zdrun.py
@@ -83,7 +83,7 @@ class ZDRunOptions(RunnerOptions):
         if self.args:
             self.program = self.args
         if not self.program:
-            self.usage("no program specified (use  positional args)")
+            self.usage("no program specified (use positional args)")
         if self.sockname:
             # Convert socket name to absolute path
             self.sockname = os.path.abspath(self.sockname)


### PR DESCRIPTION
Fixes #32.

#32 is caused by a race condition between the `SIGCHLD` signal handler and the `wait` in `subprocess.call` used to start the `start-test-program`. If the signal handler is activated before the `wait` call, the `wait` can no longer determine the process' exit status and (erroneously) claims the process exited successfully. In those cases, the start test ends prematurely.

This PR avoids the problem by letting the `SIGCHLD` handler record the exit status for unknown processes. If the start test gets a successful exit from `subprocess`, it verifies that the `SIGCHLD` handler has not recorded a contradicting exit status.

The race is very rare. To provoke it (for testing), you can uncomment the line ` import time; time.sleep(0.01)` in `zdaemon.zdrun.Subprocess.test`.