### PR TITLE
Fix a deprecation warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ Change log
 
 - Drop support for Python 3.7, 3.8.
 
+- Fix a deprecation warning by using `logger.warning` rather than `logger.warn`
+  (fixes `#40 <https://github.com/zopefoundation/zdaemon/pull/40>`_).
+
+
 5.1 (2024-05-03)
 ================
 

--- a/src/zdaemon/zdrun.py
+++ b/src/zdaemon/zdrun.py
@@ -293,7 +293,7 @@ class Daemonizer:
                     msg = "Unlinking stale socket %s; sleep 1" % sockname
                     sys.stderr.write(msg + "\n")
                     sys.stderr.flush()  # just in case
-                    self.logger.warn(msg)
+                    self.logger.warning(msg)
                     self.unlink_quietly(sockname)
                     sock.close()
                     time.sleep(1)
@@ -397,8 +397,8 @@ class Daemonizer:
             try:
                 os.chdir(self.options.directory)
             except OSError as err:
-                self.logger.warn("can't chdir into %r: %s"
-                                 % (self.options.directory, err))
+                self.logger.warning("can't chdir into %r: %s"
+                                    % (self.options.directory, err))
             else:
                 self.logger.info("set current directory: %r"
                                  % self.options.directory)
@@ -481,7 +481,7 @@ class Daemonizer:
         msg = "pid %d: " % pid + msg
         if pid != self.proc.pid:
             msg = "unknown(!=%s) " % self.proc.pid + msg
-            self.logger.warn(msg)
+            self.logger.warning(msg)
         else:
             killing = self.killing
             if killing:
@@ -656,7 +656,7 @@ class Daemonizer:
                     sent = self.commandsocket.send(msg)
                     msg = msg[sent:]
         except OSError as msg:
-            self.logger.warn("Error sending reply: %s" % str(msg))
+            self.logger.warning("Error sending reply: %s" % str(msg))
 
 
 class Transcript:


### PR DESCRIPTION
Fix a deprecation warning  by using `logger.warning` rather than `logger.warn`

Fixes #40