### PR TITLE
Replace `pkg_resources`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Change log
 5.3 (unreleased)
 ================
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` with ``importlib.metadata`` to access package
+  metadata.
 
 
 5.2 (2025-05-19)

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ setup(
     python_requires='>=3.9',
     install_requires=[
         "ZConfig",
-        "setuptools"
     ],
     extras_require=dict(test=tests_require),
 )

--- a/src/zdaemon/tests/tests.py
+++ b/src/zdaemon/tests/tests.py
@@ -35,23 +35,15 @@ from zope.testing import renormalizing
 import zdaemon
 
 
-zdaemon_spec = importlib.util.find_spec('zdaemon')
-zdaemon_loc = zdaemon_spec.origin if zdaemon_spec else None
-if zdaemon_loc:
-    zdaemon_package_dir = os.path.dirname(zdaemon_loc)
-    zdaemon_loc = os.path.dirname(zdaemon_package_dir)
-else:
-    zdaemon_package_dir = os.path.dirname(zdaemon.__file__)
-    zdaemon_loc = os.path.dirname(zdaemon_package_dir)
+_zdaemon_spec = importlib.util.find_spec('zdaemon')
+_zdaemon_origin = _zdaemon_spec.origin if _zdaemon_spec else zdaemon.__file__
+_zdaemon_package_dir = os.path.dirname(_zdaemon_origin)
+zdaemon_loc = os.path.dirname(_zdaemon_package_dir)
 
-zconfig_spec = importlib.util.find_spec('ZConfig')
-zconfig_loc = zconfig_spec.origin if zconfig_spec else None
-if zconfig_loc:
-    zconfig_package_dir = os.path.dirname(zconfig_loc)
-    zconfig_loc = os.path.dirname(zconfig_package_dir)
-else:
-    zconfig_package_dir = os.path.dirname(ZConfig.__file__)
-    zconfig_loc = os.path.dirname(zconfig_package_dir)
+_zconfig_spec = importlib.util.find_spec('ZConfig')
+_zconfig_origin = _zconfig_spec.origin if _zconfig_spec else ZConfig.__file__
+_zconfig_package_dir = os.path.dirname(_zconfig_origin)
+zconfig_loc = os.path.dirname(_zconfig_package_dir)
 
 
 def write(name, text):

--- a/src/zdaemon/tests/tests.py
+++ b/src/zdaemon/tests/tests.py
@@ -38,16 +38,20 @@ import zdaemon
 zdaemon_spec = importlib.util.find_spec('zdaemon')
 zdaemon_loc = zdaemon_spec.origin if zdaemon_spec else None
 if zdaemon_loc:
-    zdaemon_loc = os.path.dirname(os.path.dirname(zdaemon_loc))
+    package_dir = os.path.dirname(zdaemon_loc)
+    zdaemon_loc = os.path.dirname(package_dir)
 else:
-    zdaemon_loc = os.path.dirname(os.path.dirname(zdaemon.__file__))
+    package_dir = os.path.dirname(zdaemon.__file__)
+    zdaemon_loc = os.path.dirname(package_dir)
 
 zconfig_spec = importlib.util.find_spec('ZConfig')
 zconfig_loc = zconfig_spec.origin if zconfig_spec else None
 if zconfig_loc:
-    zconfig_loc = os.path.dirname(os.path.dirname(zconfig_loc))
+    package_dir = os.path.dirname(zconfig_loc)
+    zconfig_loc = os.path.dirname(package_dir)
 else:
-    zconfig_loc = os.path.dirname(os.path.dirname(ZConfig.__file__))
+    package_dir = os.path.dirname(ZConfig.__file__)
+    zconfig_loc = os.path.dirname(package_dir)
 
 
 def write(name, text):

--- a/src/zdaemon/tests/tests.py
+++ b/src/zdaemon/tests/tests.py
@@ -38,20 +38,20 @@ import zdaemon
 zdaemon_spec = importlib.util.find_spec('zdaemon')
 zdaemon_loc = zdaemon_spec.origin if zdaemon_spec else None
 if zdaemon_loc:
-    package_dir = os.path.dirname(zdaemon_loc)
-    zdaemon_loc = os.path.dirname(package_dir)
+    zdaemon_package_dir = os.path.dirname(zdaemon_loc)
+    zdaemon_loc = os.path.dirname(zdaemon_package_dir)
 else:
-    package_dir = os.path.dirname(zdaemon.__file__)
-    zdaemon_loc = os.path.dirname(package_dir)
+    zdaemon_package_dir = os.path.dirname(zdaemon.__file__)
+    zdaemon_loc = os.path.dirname(zdaemon_package_dir)
 
 zconfig_spec = importlib.util.find_spec('ZConfig')
 zconfig_loc = zconfig_spec.origin if zconfig_spec else None
 if zconfig_loc:
-    package_dir = os.path.dirname(zconfig_loc)
-    zconfig_loc = os.path.dirname(package_dir)
+    zconfig_package_dir = os.path.dirname(zconfig_loc)
+    zconfig_loc = os.path.dirname(zconfig_package_dir)
 else:
-    package_dir = os.path.dirname(ZConfig.__file__)
-    zconfig_loc = os.path.dirname(package_dir)
+    zconfig_package_dir = os.path.dirname(ZConfig.__file__)
+    zconfig_loc = os.path.dirname(zconfig_package_dir)
 
 
 def write(name, text):

--- a/src/zdaemon/tests/tests.py
+++ b/src/zdaemon/tests/tests.py
@@ -14,6 +14,7 @@
 
 import doctest
 import glob
+import importlib.util
 import os
 import re
 import shutil
@@ -34,14 +35,18 @@ from zope.testing import renormalizing
 import zdaemon
 
 
-try:
-    import pkg_resources
-    zdaemon_loc = pkg_resources.working_set.find(
-        pkg_resources.Requirement.parse('zdaemon')).location
-    zconfig_loc = pkg_resources.working_set.find(
-        pkg_resources.Requirement.parse('ZConfig')).location
-except (ModuleNotFoundError, AttributeError):
+zdaemon_spec = importlib.util.find_spec('zdaemon')
+zdaemon_loc = zdaemon_spec.origin if zdaemon_spec else None
+if zdaemon_loc:
+    zdaemon_loc = os.path.dirname(os.path.dirname(zdaemon_loc))
+else:
     zdaemon_loc = os.path.dirname(os.path.dirname(zdaemon.__file__))
+
+zconfig_spec = importlib.util.find_spec('ZConfig')
+zconfig_loc = zconfig_spec.origin if zconfig_spec else None
+if zconfig_loc:
+    zconfig_loc = os.path.dirname(os.path.dirname(zconfig_loc))
+else:
     zconfig_loc = os.path.dirname(os.path.dirname(ZConfig.__file__))
 
 

--- a/src/zdaemon/zdoptions.py
+++ b/src/zdaemon/zdoptions.py
@@ -14,11 +14,10 @@
 """Option processing for zdaemon and related code."""
 
 import getopt
+import importlib.metadata
 import os
 import signal
 import sys
-
-import pkg_resources
 
 import ZConfig
 
@@ -68,7 +67,7 @@ class ZDOptions:
         self.required_map = {}
         self.environ_map = {}
         self.zconfig_options = []
-        self.version = pkg_resources.get_distribution("zdaemon").version
+        self.version = importlib.metadata.version("zdaemon")
         self.add(None, None, "h", "help", self.help)
         self.add(None, None, None, "version", self.print_version)
         self.add("configfile", None, "C:", "configure=")


### PR DESCRIPTION
Tests in `ZEO` fail because a new deprecation warning about the end of `pkg_resources` is shown.

Example: https://github.com/zopefoundation/ZEO/actions/runs/15374800178/job/43258316457